### PR TITLE
Fix broken storage key encryption; S3 adapter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ etc) into the one of the encryption adapters. Here's an example
 ```php
 $adapter = new \ObjectStorage\Adapter\EncryptedStorageAdapter(
     new \ObjectStorage\Adapter\PdoAdapter($pdo),
-    \ParagonIE\Halite\KeyFactory::loadEncryptionKey($pathToKeyfile)
+    \ParagonIE\Halite\KeyFactory::loadAuthenticationKey($pathToSigningKey),
+    \ParagonIE\Halite\KeyFactory::loadEncryptionKey($pathToEncryptionKey)
 );
 // You can use $adapter as before and both the storage keys and objects will be
 // encrypted (use PlaintextKeyEncryptedStorageAdapter if you don't want the
@@ -94,10 +95,12 @@ $adapter = new \ObjectStorage\Adapter\EncryptedStorageAdapter(
 
 The encryption routines are provided by [ParagonIE/Halite][] and libsodium.
 
-Use the following command to generate an encryption key and save it to a file :-
+Use the following commands to generate and save a signing key and an encryption
+key as needed in the previous example:-
 
 ```sh
-./bin/objectstorage genkey /path/to/a/file
+./bin/objectstorage genkey --signing /path/to/a/file
+./bin/objectstorage genkey /path/to/another/file
 ```
 
 You can also use the included encrypt + decrypt commands.  In the following

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/console": "^4",
         "aws/aws-sdk-php": "^3",
         "friendsofphp/php-cs-fixer": "^2.15",
+        "phpstan/phpstan": "^0.11.8",
         "phpunit/phpunit": "^8.1"
     },
     "suggest": {
@@ -28,6 +29,11 @@
         "psr-4": {
             "ObjectStorage\\": "src/"
         } 
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ObjectStorage\\Test\\": "tests/"
+        }
     },
     "license": "MIT"
 }

--- a/src/Adapter/AbstractEncryptedStorageAdapter.php
+++ b/src/Adapter/AbstractEncryptedStorageAdapter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ObjectStorage\Adapter;
+
+use ParagonIE\Halite\Symmetric\EncryptionKey;
+
+/**
+ * Base class for encrypted storage adapters.
+ */
+abstract class AbstractEncryptedStorageAdapter
+{
+    const CFG_AUTHENTICATION_KEY = 'authentication_key';
+    const CFG_AUTHENTICATION_KEY_PATH = 'authentication_key_path';
+    const CFG_ENCRYPTION_KEY = 'encryption_key';
+    const CFG_ENCRYPTION_KEY_PATH = 'encryption_key_path';
+    const CFG_STORAGE_ADAPTER = 'storage_adapter';
+
+    protected $encryptionKey;
+    protected $storageAdapter;
+
+    public function setAdapter(StorageAdapterInterface $storageAdapter)
+    {
+        $this->storageAdapter = $storageAdapter;
+    }
+
+    public function setEncryptionKey(EncryptionKey $encryptionKey)
+    {
+        $this->encryptionKey = $encryptionKey;
+    }
+}

--- a/src/Adapter/EncryptedStorageAdapter.php
+++ b/src/Adapter/EncryptedStorageAdapter.php
@@ -5,6 +5,7 @@ namespace ObjectStorage\Adapter;
 use ParagonIE\Halite\Alerts\CannotPerformOperation;
 use ParagonIE\Halite\Halite;
 use ParagonIE\Halite\KeyFactory;
+use ParagonIE\Halite\Symmetric\AuthenticationKey;
 use ParagonIE\Halite\Symmetric\Crypto;
 use ParagonIE\Halite\Symmetric\EncryptionKey;
 use ParagonIE\HiddenString\HiddenString;
@@ -13,24 +14,46 @@ use ParagonIE\HiddenString\HiddenString;
  * Decorates a storage adapter to encrypt and decrypt object data and the keys
  * by which the data are stored.
  */
-class EncryptedStorageAdapter implements StorageAdapterInterface
+class EncryptedStorageAdapter extends AbstractEncryptedStorageAdapter implements StorageAdapterInterface
 {
-    const CFG_ENCRYPTION_KEY = 'encryption_key';
-    const CFG_ENCRYPTION_KEY_PATH = 'encryption_key_path';
-    const CFG_STORAGE_ADAPTER = 'storage_adapter';
-
+    protected $authenticationKey;
     protected $encryptionKey;
     protected $storageAdapter;
 
     public static function build(array $config)
     {
-        if (!isset($config[self::CFG_ENCRYPT_STORAGE_ADAPTER])
-            || !$config[self::CFG_ENCRYPT_STORAGE_ADAPTER] instanceof StorageAdapterInterface
+        if (!isset($config[self::CFG_STORAGE_ADAPTER])
+            || !$config[self::CFG_STORAGE_ADAPTER] instanceof StorageAdapterInterface
         ) {
             throw new \InvalidArgumentException(
                 'The build configuration for this storage adapter is missing an instance of StorageAdapterInterface, keyed as "'
                     . self::CFG_STORAGE_ADAPTER
                     . '"."'
+            );
+        }
+
+        if (isset($config[self::CFG_AUTHENTICATION_KEY])) {
+            if (!$config[self::CFG_AUTHENTICATION_KEY] instanceof AuthenticationKey) {
+                throw new \InvalidArgumentException(
+                    '"' . self::CFG_AUTHENTICATION_KEY . '"  must be an instance of AuthenticationKey.'
+                );
+            }
+            $authenticationKey = $config[self::CFG_AUTHENTICATION_KEY];
+        } elseif (isset($config[self::CFG_AUTHENTICATION_KEY_PATH])) {
+            try {
+                $authenticationKey = KeyFactory::loadAuthenticationKey($config[self::CFG_AUTHENTICATION_KEY_PATH]);
+            } catch (CannotPerformOperation $e) {
+                throw new \InvalidArgumentException(
+                    '"' . self::CFG_AUTHENTICATION_KEY_PATH . '"  must be a readable file.'
+                );
+            }
+        } else {
+            throw new \InvalidArgumentException(
+                'The build configuration for this storage adapter is missing an authentication key ("'
+                    . self::CFG_AUTHENTICATION_KEY
+                    . '" or "'
+                    . self::CFG_AUTHENTICATION_KEY_PATH
+                    . '").'
             );
         }
 
@@ -60,89 +83,97 @@ class EncryptedStorageAdapter implements StorageAdapterInterface
         }
 
         return new self(
-            $config[self::CFG_ENCRYPT_STORAGE_ADAPTER],
+            $config[self::CFG_STORAGE_ADAPTER],
+            $authenticationKey,
             $encryptionKey
         );
     }
 
     public function __construct(
         StorageAdapterInterface $storageAdapter,
+        AuthenticationKey $authenticationKey,
         EncryptionKey $encryptionKey
     ) {
         $this->storageAdapter = $storageAdapter;
+        $this->authenticationKey = $authenticationKey;
         $this->encryptionKey = $encryptionKey;
     }
 
-    public function setAdapter(StorageAdapterInterface $storageAdapter)
+    public function setAuthenticationKey(AuthenticationKey $authenticationKey)
     {
-        $this->storageAdapter = $storageAdapter;
-    }
-
-    public function setEncryptionKey(EncryptionKey $encryptionKey)
-    {
-        $this->encryptionKey = $encryptionKey;
+        $this->authenticationKey = $authenticationKey;
     }
 
     public function setData($key, $data)
     {
         try {
-            $encryptedStorageKey = Crypto::encrypt(
-                new HiddenString($key),
-                $this->encryptionKey,
+            $authenticStorageKey = Crypto::authenticate(
+                $key,
+                $this->authenticationKey,
                 Halite::ENCODE_BASE64URLSAFE
             );
         } catch (CannotPerformOperation $e) {
-            throw new EncryptionFailureException('Failed to encrypt the storage key.', null, $e);
+            throw new EncryptionFailureException('Failed to hash the storage key.', null, $e);
         }
 
         try {
-            $encryptedData = Crypto::encrypt(
-                new HiddenString($data),
+            $encryptedBlob = Crypto::encrypt(
+                new HiddenString($key . $data),
                 $this->encryptionKey,
                 Halite::ENCODE_BASE64URLSAFE
             );
         } catch (CannotPerformOperation $e) {
-            throw new EncryptionFailureException('Failed to encrypt the object data.', null, $e);
+            throw new EncryptionFailureException('Failed to encrypt the storage key and object data.', null, $e);
         }
 
-        return $this->storageAdapter->setData($encryptedStorageKey, $encryptedData);
+        return $this->storageAdapter->setData($authenticStorageKey, $encryptedBlob);
     }
 
     public function getData($key)
     {
         try {
-            $encryptedStorageKey = Crypto::encrypt(
-                new HiddenString($key),
-                $this->encryptionKey,
+            $authenticStorageKey = Crypto::authenticate(
+                $key,
+                $this->authenticationKey,
                 Halite::ENCODE_BASE64URLSAFE
             );
         } catch (CannotPerformOperation $e) {
-            throw new EncryptionFailureException('Failed to encrypt the storage key.', null, $e);
+            throw new EncryptionFailureException('Failed to hash the storage key.', null, $e);
         }
 
-        $encryptedData = $this->storageAdapter->getData($encryptedStorageKey);
+        $encryptedBlob = $this->storageAdapter->getData($authenticStorageKey);
 
         try {
-            $plaintextData = (string) Crypto::decrypt($encryptedData, $this->encryptionKey);
+            $plaintextBlob = (string) Crypto::decrypt($encryptedBlob, $this->encryptionKey);
         } catch (CannotPerformOperation $e) {
-            throw new EncryptionFailureException('Failed to decrypt the object data.', null, $e);
+            throw new EncryptionFailureException('Failed to decrypt the storage key and object data.', null, $e);
         }
 
-        return $plaintextData;
+        $storageKeyLength = \strlen($key);
+
+        if (false === \hash_equals($key, \substr($plaintextBlob, 0, $storageKeyLength))) {
+            // The $plaintextBlob was definitely encrypted with our encryption key,
+            // but the storage key is not the one in that blob.
+            throw new EncryptionFailureException(
+                'The object data is not the expected one for the supplied storage key. The store has been corrupted or tampered with.'
+            );
+        }
+
+        return \substr($plaintextBlob, $storageKeyLength);
     }
 
     public function deleteData($key)
     {
         try {
-            $encryptedStorageKey = Crypto::encrypt(
-                new HiddenString($key),
-                $this->encryptionKey,
+            $authenticStorageKey = Crypto::authenticate(
+                $key,
+                $this->authenticationKey,
                 Halite::ENCODE_BASE64URLSAFE
             );
         } catch (CannotPerformOperation $e) {
-            throw new EncryptionFailureException('Failed to encrypt the storage key.', null, $e);
+            throw new EncryptionFailureException('Failed to hash the storage key.', null, $e);
         }
 
-        return $this->storageAdapter->deleteData($encryptedStorageKey);
+        return $this->storageAdapter->deleteData($authenticStorageKey);
     }
 }

--- a/src/Adapter/S3Adapter.php
+++ b/src/Adapter/S3Adapter.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 class S3Adapter implements BuildableAdapterInterface, StorageAdapterInterface
 {
     const DEFAULT_ACL = 'public-read';
+    const DEFAULT_API_VERSION = '2006-03-01';
 
     private $s3client = null;
     private $bucketname = null;
@@ -37,15 +38,29 @@ class S3Adapter implements BuildableAdapterInterface, StorageAdapterInterface
                 'Unable to build S3Adapter: missing "bucketname" from configuration.'
             );
         }
+        if (!array_key_exists('region', $config)
+            || '' === trim($config['region'])
+        ) {
+            throw new InvalidArgumentException(
+                'Unable to build S3Adapter: missing "region" from configuration.'
+            );
+        }
+        if (!array_key_exists('version', $config)) {
+            $config['version'] = self::DEFAULT_API_VERSION;
+        }
         $prefix = '';
         if (isset($config['prefix'])) {
             $prefix = trim($config['prefix']);
         }
 
-        $client = S3Client::factory(
+        $client = new S3Client(
             [
-                'key' => trim($config['access_key']),
-                'secret' => trim($config['secret_key']),
+                'credentials' => [
+                    'key' => trim($config['access_key']),
+                    'secret' => trim($config['secret_key']),
+                ],
+                'region' => trim($config['region']),
+                'version' => trim($config['version']),
             ]
         );
 

--- a/src/Command/GenerateKeyCommand.php
+++ b/src/Command/GenerateKeyCommand.php
@@ -4,24 +4,31 @@ namespace ObjectStorage\Command;
 
 use ParagonIE\Halite\KeyFactory;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateKeyCommand extends Command
 {
     const ARG_PATH = 'path';
+    const OPT_SIGNING = 'signing';
 
     protected function configure()
     {
         $this->setName('genkey')
             ->setDescription(
-                'Generate a symmetric encryption key and write it to a file at the supplied path.  This command will not overwrite an existing file.'
+                'Generate a symmetric encryption or signing key and write it to a file at the supplied path.  This command will not overwrite an existing file.'
             )
             ->addArgument(
                 self::ARG_PATH,
                 InputArgument::REQUIRED,
                 'The path to which to save the key file.'
+            )
+            ->addOption(
+                self::OPT_SIGNING,
+                's',
+                InputOption::VALUE_NONE
             )
         ;
     }
@@ -36,10 +43,22 @@ class GenerateKeyCommand extends Command
             return 1;
         }
 
+        if (null !== $input->getOption(self::OPT_SIGNING)) {
+            if (true !== KeyFactory::save(KeyFactory::generateAuthenticationKey(), $path)) {
+                $output->writeln("I tried, but was unable to write the signing key to a file at \"{$path}\". I apologise!");
+
+                return 2;
+            }
+
+            return 0;
+        }
+
         if (true !== KeyFactory::save(KeyFactory::generateEncryptionKey(), $path)) {
-            $output->writeln("I tried, but was unable to write the key to a file at \"{$path}\". I apologise!");
+            $output->writeln("I tried, but was unable to write the encryption key to a file at \"{$path}\". I apologise!");
 
             return 2;
         }
+
+        return 0;
     }
 }

--- a/src/Command/GenerateKeyCommand.php
+++ b/src/Command/GenerateKeyCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class GenerateKeyCommand extends Command
 {
@@ -35,29 +36,33 @@ class GenerateKeyCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
+
         $path = $input->getArgument(self::ARG_PATH);
 
         if (\file_exists($path)) {
-            $output->writeln("I cannot create a key file at \"{$path}\" because a file exists there already. I stop!");
+            $io->error("I cannot create a key file at \"{$path}\" because a file exists there already. I stop!");
 
             return 1;
         }
 
-        if (null !== $input->getOption(self::OPT_SIGNING)) {
+        if ($input->getOption(self::OPT_SIGNING)) {
             if (true !== KeyFactory::save(KeyFactory::generateAuthenticationKey(), $path)) {
-                $output->writeln("I tried, but was unable to write the signing key to a file at \"{$path}\". I apologise!");
+                $io->error("I tried, but was unable to write the signing key to a file at \"{$path}\". I apologise!");
 
                 return 2;
             }
+            $io->success("Signing key saved to \"{$path}\".");
 
             return 0;
         }
 
         if (true !== KeyFactory::save(KeyFactory::generateEncryptionKey(), $path)) {
-            $output->writeln("I tried, but was unable to write the encryption key to a file at \"{$path}\". I apologise!");
+            $io->error("I tried, but was unable to write the encryption key to a file at \"{$path}\". I apologise!");
 
             return 2;
         }
+        $io->success("Encryption key saved to \"{$path}\".");
 
         return 0;
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -4,7 +4,6 @@ namespace ObjectStorage;
 
 use InvalidArgumentException;
 use RuntimeException;
-use ObjectStorage\Adapter\EncryptionAdapter;
 use ObjectStorage\Adapter\Bzip2Adapter;
 
 class Utils
@@ -50,11 +49,7 @@ class Utils
         $adapter = $adapterclassname::build($config[$adaptername]);
 
         if (isset($config['encryption'])) {
-            $key = (string) $config['encryption']['key'];
-            $iv = (string) $config['encryption']['iv'];
-
-            // Wrap the real adapter into the encryption adapter
-            $adapter = new EncryptionAdapter($adapter, $key, $iv);
+            throw new RuntimeException('It is no longer possible to configure encrypted storage from objectstore.conf.');
         }
 
         if (isset($config['bzip2'])) {

--- a/tests/Adapter/EncryptedStorageAdapterTest.php
+++ b/tests/Adapter/EncryptedStorageAdapterTest.php
@@ -12,12 +12,14 @@ use PHPUnit\Framework\TestCase;
 
 class EncryptedStorageAdapterTest extends TestCase
 {
+    private $authenticationKey;
     private $encryptedStorageAdapter;
     private $encryptionKey;
     private $storageAdapter;
 
     protected function setUp(): void
     {
+        $this->authenticationKey = KeyFactory::generateAuthenticationKey();
         $this->encryptionKey = KeyFactory::generateEncryptionKey();
 
         $this->storageAdapter = $this->getMockBuilder(StorageAdapterInterface::class)
@@ -26,6 +28,7 @@ class EncryptedStorageAdapterTest extends TestCase
 
         $this->encryptedStorageAdapter = new EncryptedStorageAdapter(
             $this->storageAdapter,
+            $this->authenticationKey,
             $this->encryptionKey
         );
     }
@@ -37,7 +40,7 @@ class EncryptedStorageAdapterTest extends TestCase
             ->method('setData')
             ->with(
                 new LogicalNot('some-key'),
-                new LogicalNot('some-data')
+                new LogicalNot('some-keysome-data')
             )
         ;
 
@@ -50,7 +53,7 @@ class EncryptedStorageAdapterTest extends TestCase
             ->expects($this->once())
             ->method('getData')
             ->with(new LogicalNot('some-key'))
-            ->willReturn(Crypto::encrypt(new HiddenString('some-data'), $this->encryptionKey))
+            ->willReturn(Crypto::encrypt(new HiddenString('some-keysome-data'), $this->encryptionKey))
         ;
 
         $this->encryptedStorageAdapter->getData('some-key');


### PR DESCRIPTION
- 0c8f61f Changes

        `setData(encrypt(key), encrypt(object))`

    to

        `setData(hash(key), encrypt(concat(key, object)))`

    so that we can actually retrive our objects ;) and to provide assurance that:-

    - keys aren't leaked
    - keys and objects are assured to be authentic
    - objects cannot have their keys maliciously "swapped"

- d9cec37 fixes the S3 adapter so that it works with a modern aws-sdk-php

- 4e51144 changes the default S3 "canned ACL" to private from readable by the public; this can now be configured per instance of the S3 adapter
