### PR TITLE
Help library users react better to Object Storage failures

### DIFF
--- a/src/Adapter/S3Adapter.php
+++ b/src/Adapter/S3Adapter.php
@@ -2,6 +2,8 @@
 
 namespace ObjectStorage\Adapter;
 
+use Aws\Exception\AwsException;
+use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use InvalidArgumentException;
 
@@ -106,35 +108,53 @@ class S3Adapter implements BuildableAdapterInterface, StorageAdapterInterface
 
     public function setData($key, $data)
     {
-        $this->s3client->putObject(
-            [
-                'Bucket' => $this->bucketname,
-                'Key' => $this->prefix . $key,
-                'Body' => $data,
-                'ACL' => $this->cannedAcl,
-            ]
-        );
+        try {
+            $this->s3client->putObject(
+                [
+                    'Bucket' => $this->bucketname,
+                    'Key' => $this->prefix . $key,
+                    'Body' => $data,
+                    'ACL' => $this->cannedAcl,
+                ]
+            );
+        } catch (S3Exception $e) {
+            throw new AdapterException('Failed to store data because of an S3 error', null, $e);
+        } catch (AwsException $e) {
+            throw new AdapterException('Failed to store data because of an AWS error', null, $e);
+        }
     }
 
     public function getData($key)
     {
-        $result = $this->s3client->getObject(
-            [
-                'Bucket' => $this->bucketname,
-                'Key' => $this->prefix . $key,
-            ]
-        );
+        try {
+            $result = $this->s3client->getObject(
+                [
+                    'Bucket' => $this->bucketname,
+                    'Key' => $this->prefix . $key,
+                ]
+            );
+        } catch (S3Exception $e) {
+            throw new AdapterException('Failed to retrieve data because of an S3 error', null, $e);
+        } catch (AwsException $e) {
+            throw new AdapterException('Failed to retrieve data because of an AWS error', null, $e);
+        }
 
         return (string) $result['Body'];
     }
 
     public function deleteData($key)
     {
-        $this->s3client->deleteObject(
-            [
-                'Bucket' => $this->bucketname,
-                'Key' => $this->prefix . $key,
-            ]
-        );
+        try {
+            $this->s3client->deleteObject(
+                [
+                    'Bucket' => $this->bucketname,
+                    'Key' => $this->prefix . $key,
+                ]
+            );
+        } catch (S3Exception $e) {
+            throw new AdapterException('Failed to delete data because of an S3 error', null, $e);
+        } catch (AwsException $e) {
+            throw new AdapterException('Failed to delete data because of an AWS error', null, $e);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Catch exceptions thrown by the AWS S3 and throw AdapterException to help library users react better to Object storage failures.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

In practice, it is unlikely that this will affect users of this library because they are probably not themselves catching AWS and S3 Exceptions.  Nevertheless, this PR should be followed by a major version number increment (i.e. **v5**).
